### PR TITLE
Fixes #9: CPU spike if jspm_packages is not in root dir.

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ module.exports = (opts, cb) => {
   }
   let pathToWath = opts.path || baseURL || '.'
   let chokidarOpts = Object.assign({
-    ignored: [/[\/\\]\./, 'node_modules/**', 'jspm_packages/**'],
+    ignored: [/[\/\\]\./, 'node_modules/**', baseURL + '/jspm_packages/**'],
     ignoreInitial: true
   }, opts.chokidar)
   var watcher = chokidar.watch(pathToWath, chokidarOpts).on('all', (event, onPath) => {


### PR DESCRIPTION
Make sure the ignore list containing jspm_packages takes baseURL into account
