### PR TITLE
Adding support for ignoring paths via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ var chokidarEvEmitter = require('chokidar-socket-emitter')
 chokidarEvEmitter({port: 8090}) //path is taken from jspm/directories/baseURL or if that is not set up, '.' is used
 //or specify the path
 chokidarEvEmitter({port: 8090, path: '.'})
+//or ignore some
+chokidarEvEmitter({port: 8090, ignorePaths: 'tests/'})
 
 //you can also supply an http server instance, that way it will run within your server, no need for extra port
 require('chokidar-socket-emitter')({app: server})

--- a/server.js
+++ b/server.js
@@ -35,7 +35,7 @@ module.exports = (opts, cb) => {
     'node_modules/**',
     baseURL + '/jspm_packages/**',
     '.git/**'
-  ]
+  ].concat(opts.ignorePaths || [])
   let chokidarOpts = Object.assign({
     ignored: ignoredPaths,
     ignoreInitial: true

--- a/test/chokidar-socket-emitter.spec.js
+++ b/test/chokidar-socket-emitter.spec.js
@@ -51,6 +51,25 @@ describe('chokidar-socket-emitter', function () {
     })
   })
 
+  it('should expose watcher for manual event subscription', function (done) {
+    chokidarServer = chokidarEvEmitter({port: 7090}, done)
+  })
+
+  it('should respect ignored files', function (done) {
+    chokidarServer = chokidarEvEmitter({port: 7090, path: './test/test-folder', relativeTo: './test', ignorePaths: ['./test/test-folder']})
+    var socket = require('socket.io-client')('http://localhost:7090')
+    socket.on('change', function (data) {
+      expect(false).to.equal(true)
+      done()
+    })
+    setTimeout(() => {
+      fs.writeFile('./test/test-folder/labrat.txt', 'test1', (error) => {
+        expect(error).to.equal(null)
+        setTimeout(() => { done() }, 1000)
+      })
+    }, 300)
+  })
+
   afterEach(function (done) {
     setTimeout(() => {
       chokidarServer.close(done)


### PR DESCRIPTION
Hey Capaj, I would like to make things a little cleaner in my setup by excluding some directories that are already being watched by other processes (i.e. tests). Since it's a list of paths that would be passed in, I'm not sure what is the best way to handle this in the CLI, so I only did it for the Programatic usage. Let me know your thoughts.
