### PR TITLE
Fix CLI and ignored file bugs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,6 +15,8 @@ var opts = {}
 
 opts.port = program.port || '5776'
 
+opts.path = program.path
+
 opts.dir = program.dir || path.resolve('.')
 
 if (program.poll) {

--- a/server.js
+++ b/server.js
@@ -32,8 +32,10 @@ module.exports = (opts, cb) => {
   const pathToWatch = opts.path || baseURL || '.'
   let ignoredPaths = [
     /[\/\\]\./,
+    // Ignore relative, top-level dotfiles as well (e.g. '.gitignore').
+    /^\.[^\/\\]/,
     'node_modules/**',
-    baseURL + '/jspm_packages/**',
+    (baseURL ? baseURL + '/' : '') + 'jspm_packages/**',
     '.git/**'
   ]
   let chokidarOpts = Object.assign({


### PR DESCRIPTION
When running the CLI command (on Windows through Git Bash), I found that:
1. the `--path` option was never being passed in, so it always chose `.`, and
2. certain paths which should be ignored, weren't.
