### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -43,7 +43,7 @@ module.exports = (opts, cb) => {
     ignoreInitial: true
   }, opts.chokidar)
   console.log('chokidar watching ', path.resolve(pathToWatch))
-  var watcher = chokidar.watch(pathToWatch, chokidarOpts).on('all', (event, onPath) => {
+  var watcher = chokidar.watch(path.resolve(pathToWatch), chokidarOpts).on('all', (event, onPath) => {
     let absolutePath = path.join(process.cwd(), onPath)
     if (opts.relativeTo) {
       onPath = path.relative(opts.relativeTo, onPath)


### PR DESCRIPTION
pathToWatch was failing to watch for me on relative paths.  Once I resolved it before passing it to chokidar-watch, it resolved my issue

I am on windows, and I needed a path of '../app' which didn't work.
