### PR TITLE
Update server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const chokidar = require('chokidar')
 const path = require('path')
 const socketsConnected = []
 
-module.exports = (opts, cb) => {
+module.exports = (opts={}, cb) => {
   let baseURL
   let pjson
   let error
@@ -23,7 +23,7 @@ module.exports = (opts, cb) => {
 
   var io = require('socket.io')(app)
   if (!opts.app) {
-    let port = opts.port || 9111
+    let port = opts.port || 5776
     app.listen(port, () => {
       console.log('chokidar-socket-emitter listening on ' + port)
       cb && cb()


### PR DESCRIPTION
Allowing default Programatic usage with defaults similar to cli usage, ie:

`require('chokidar-socket-emitter')()` By default listens on port 5776, without having to pass in an empty opts object.
